### PR TITLE
Handle null asesor timestamps and fix email-uniqueness on update

### DIFF
--- a/app/Http/Requests/UpdateAsesorRequest.php
+++ b/app/Http/Requests/UpdateAsesorRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateAsesorRequest extends FormRequest
 {
@@ -21,11 +22,17 @@ class UpdateAsesorRequest extends FormRequest
      */
     public function rules(): array
     {
-        $asesorId = $this->route('asesor'); // Get the ID from route parameter
+        $asesorRouteParam = $this->route('asesor');
+        $asesorId = is_object($asesorRouteParam) ? $asesorRouteParam->getKey() : $asesorRouteParam;
         
         return [
             'nama' => 'required|string|max:255',
-            'email' => 'required|email|max:255|unique:users,email,' . $asesorId,
+            'email' => [
+                'required',
+                'email',
+                'max:255',
+                Rule::unique('users', 'email')->ignore($asesorId),
+            ],
             'password' => 'nullable|string|min:8|regex:/^(?=.*[a-zA-Z])(?=.*\d).+$/|confirmed',
             'password_confirmation' => 'required_with:password',
             'no_hp' => 'required|string|max:20',

--- a/resources/views/admin/asesor/edit.blade.php
+++ b/resources/views/admin/asesor/edit.blade.php
@@ -163,13 +163,13 @@
                                 <div class="col-md-6">
                                     <small class="text-muted">
                                         <i class="bi bi-calendar-plus me-1"></i>
-                                        <strong>Terdaftar:</strong> {{ $asesor->created_at->format('d F Y, H:i') }}
+                                        <strong>Terdaftar:</strong> {{ $asesor->created_at?->format('d F Y, H:i') ?? '-' }}
                                     </small>
                                 </div>
                                 <div class="col-md-6">
                                     <small class="text-muted">
                                         <i class="bi bi-calendar-check me-1"></i>
-                                        <strong>Terakhir diupdate:</strong> {{ $asesor->updated_at->format('d F Y, H:i') }}
+                                        <strong>Terakhir diupdate:</strong> {{ $asesor->updated_at?->format('d F Y, H:i') ?? '-' }}
                                     </small>
                                 </div>
                             </div>


### PR DESCRIPTION
### Motivation
- Prevent view errors when an `asesor` has null timestamps and ensure the edit form actually saves when the email is unchanged during update.
- The edit view previously called `format()` on possibly-null timestamps causing runtime errors, and the update request validation could reject the current asesor's unchanged email as a duplicate.

### Description
- Updated `resources/views/admin/asesor/edit.blade.php` to render timestamps with null-safe access and fallback: `{{ $asesor->created_at?->format('d F Y, H:i') ?? '-' }}` and `{{ $asesor->updated_at?->format('d F Y, H:i') ?? '-' }}`.
- Updated `app/Http/Requests/UpdateAsesorRequest.php` to import `Illuminate\Validation\Rule` and robustly resolve the route parameter (supporting model binding or id) before using `Rule::unique('users','email')->ignore($asesorId)` so the current asesor's email is excluded from uniqueness checks.

### Testing
- Ran `php -l resources/views/admin/asesor/edit.blade.php` which reported no syntax errors.
- Ran `php -l app/Http/Requests/UpdateAsesorRequest.php` which reported no syntax errors.
- Attempted `php artisan route:list --name=admin.asesor.update` but it failed due to missing `vendor/autoload.php` in the environment, so route-level runtime checks were not executed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ad23694dc8328a19efde957e84e82)