### PR TITLE
Refactor asesor penilaian show view with card layout and Bootstrap form styling

### DIFF
--- a/resources/views/asesor/penilaian/show.blade.php
+++ b/resources/views/asesor/penilaian/show.blade.php
@@ -1,42 +1,64 @@
 @extends('layouts.asesor')
 
+@section('page-title', 'Penilaian Asesi')
+
 @section('content')
-<h4>Penilaian Skema: {{ $pengajuan->program->nama }}</h4>
-<p>Asesi: {{ $pengajuan->user->nama }}</p>
+<div class="container-fluid px-0">
+    <div class="card shadow-sm border-0 mb-4">
+        <div class="card-body">
+            <h4 class="mb-1">Penilaian Skema: {{ $pengajuan->program->nama }}</h4>
+            <p class="text-muted mb-0">Asesi: {{ $pengajuan->user->nama }}</p>
+        </div>
+    </div>
 
-<form method="POST" action="{{ route('asesor.pengajuan.store', $pengajuan->id) }}">
-@csrf
+    <form method="POST" action="{{ route('asesor.pengajuan.store', $pengajuan->id) }}" class="vstack gap-4">
+        @csrf
 
-@forelse($pengajuan->program->units as $unit)
-    <h5>{{ $unit->judul_unit }}</h5>
+        @forelse($pengajuan->program->units as $unit)
+            <div class="card shadow-sm border-0">
+                <div class="card-header bg-white py-3">
+                    <h5 class="mb-0">{{ $unit->judul_unit }}</h5>
+                </div>
+                <div class="card-body">
+                    @forelse($unit->elemenKompetensis as $elemen)
+                        <div class="mb-4">
+                            <h6 class="fw-bold mb-3">{{ $elemen->nama_elemen }}</h6>
 
-    @forelse($unit->elemenKompetensis as $elemen)
-        <b>{{ $elemen->nama_elemen }}</b>
+                            <div class="vstack gap-3">
+                                @foreach($elemen->kriteriaUnjukKerja as $kuk)
+                                    <div class="border rounded p-3 bg-light-subtle">
+                                        <label class="form-label fw-semibold d-block mb-2" for="nilai_{{ $kuk->id }}">
+                                            {{ $kuk->deskripsi }}
+                                        </label>
 
-        <ul>
-        @foreach($elemen->kriteriaUnjukKerja as $kuk)
-            <li>
-                {{ $kuk->deskripsi }}
+                                        <div class="row g-3">
+                                            <div class="col-lg-4 col-md-5">
+                                                <select id="nilai_{{ $kuk->id }}" name="nilai[{{ $kuk->id }}]" class="form-select" required>
+                                                    <option value="">-- Pilih --</option>
+                                                    <option value="kompeten" {{ old('nilai.' . $kuk->id) === 'kompeten' ? 'selected' : '' }}>Kompeten</option>
+                                                    <option value="belum_kompeten" {{ old('nilai.' . $kuk->id) === 'belum_kompeten' ? 'selected' : '' }}>Belum Kompeten</option>
+                                                </select>
+                                            </div>
+                                            <div class="col-lg-8 col-md-7">
+                                                <textarea name="catatan[{{ $kuk->id }}]" class="form-control" rows="2" placeholder="Catatan untuk kriteria ini (opsional)">{{ old('catatan.' . $kuk->id) }}</textarea>
+                                            </div>
+                                        </div>
+                                    </div>
+                                @endforeach
+                            </div>
+                        </div>
+                    @empty
+                        <p class="text-muted mb-0">Belum ada elemen kompetensi untuk unit ini.</p>
+                    @endforelse
+                </div>
+            </div>
+        @empty
+            <div class="alert alert-secondary mb-0">Belum ada unit kompetensi pada program ini.</div>
+        @endforelse
 
-                <select name="nilai[{{ $kuk->id }}]" required>
-                    <option value="">-- Pilih --</option>
-                    <option value="kompeten">Kompeten</option>
-                    <option value="belum_kompeten">Belum Kompeten</option>
-                </select>
-
-                <br>
-                <textarea name="catatan[{{ $kuk->id }}]" placeholder="Catatan..."></textarea>
-            </li>
-        @endforeach
-        </ul>
-    @empty
-        <p class="text-muted">Belum ada elemen kompetensi untuk unit ini.</p>
-    @endforelse
-@empty
-    <p class="text-muted">Belum ada unit kompetensi pada program ini.</p>
-@endforelse
-
-<button class="btn btn-success">Simpan Penilaian</button>
-
-</form>
+        <div>
+            <button type="submit" class="btn btn-success px-4">Simpan Penilaian</button>
+        </div>
+    </form>
+</div>
 @endsection


### PR DESCRIPTION
### Motivation
- Improve readability and visual hierarchy of the asesor penilaian page so evaluators can scan units, elements, and KUKs more easily.
- Standardize form controls and spacing so dropdowns and notes are aligned and usable on different device widths.

### Description
- Refactored `resources/views/asesor/penilaian/show.blade.php` to wrap header info in a card and render each `unit` as a Bootstrap card for clearer sections.
- Converted each KUK item into a responsive form block using a grid, `label`, `select` with `form-select`, and `textarea` with `form-control` for consistent styling.
- Preserved previous input on validation by using `old('nilai.<id>')` and `old('catatan.<id>')`, and added a page title via `@section('page-title', 'Penilaian Asesi')`.
- Improved empty-state messaging for missing units/elements and added a styled submit button (`btn btn-success`).

### Testing
- Ran `php artisan test`, which failed in this environment because `vendor/autoload.php` is missing and project dependencies are not installed, so unit tests could not be executed.
- Ran an automated browser script to capture a screenshot of `http://localhost:8000/asesor/pengajuan/1/penilaian`, which produced an artifact but the local URL returned `Not Found` in this environment, so visual verification is limited.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698af72187ec832892974fd079a370a0)