### PR TITLE
Add admin certificate upload and reports

### DIFF
--- a/app/Http/Controllers/Admin/DashboardController.php
+++ b/app/Http/Controllers/Admin/DashboardController.php
@@ -1,24 +1,32 @@
 <?php
+
 namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
-use App\Models\ProgramPelatihan;
-use App\Models\UnitKompetensi;
-use App\Models\User;
-use App\Models\ProfesiTerkait;
+use App\Models\JadwalAsesmen;
 use App\Models\PengajuanSkema;
+use App\Models\ProfesiTerkait;
+use App\Models\ProgramPelatihan;
+use App\Models\Sertifikat;
+use App\Models\UnitKompetensi;
 
 class DashboardController extends Controller
 {
-     public function index()
+    public function index()
     {
         // STAT KOTAK ATAS
-        $totalProgram  = ProgramPelatihan::where('is_published', 1)->count();
-        $totalUnit     = UnitKompetensi::count();
-        $totalProfesi  = ProfesiTerkait::count();
+        $totalProgram = ProgramPelatihan::where('is_published', 1)->count();
+        $totalUnit = UnitKompetensi::count();
+        $totalProfesi = ProfesiTerkait::count();
 
         // jumlah asesi = user yang pernah mengajukan skema (distinct user_id)
-        $totalAsesi    = PengajuanSkema::distinct('user_id')->count('user_id');
+        $totalAsesi = PengajuanSkema::distinct('user_id')->count('user_id');
+        $totalPengajuanMenunggu = PengajuanSkema::where('status', 'pending')->count();
+        $totalJadwalSelesai = JadwalAsesmen::where('status', 'completed')->count();
+        $totalSertifikatTerbit = Sertifikat::count();
+        $totalSertifikatPerluUpload = PengajuanSkema::whereHas('jadwalAsesmen', function ($query) {
+            $query->where('status', 'completed');
+        })->whereDoesntHave('sertifikat')->count();
 
         // PROGRAM TERBARU
         $programTerbaru = ProgramPelatihan::orderByDesc('created_at')
@@ -31,15 +39,27 @@ class DashboardController extends Controller
             ->take(5)
             ->get();
 
+        $sertifikatPerluUpload = PengajuanSkema::with(['program', 'user', 'jadwalAsesmen'])
+            ->whereHas('jadwalAsesmen', function ($query) {
+                $query->where('status', 'completed');
+            })
+            ->whereDoesntHave('sertifikat')
+            ->latest('updated_at')
+            ->take(5)
+            ->get();
+
         return view('admin.dashboard', compact(
             'totalProgram',
             'totalUnit',
             'totalProfesi',
             'totalAsesi',
+            'totalPengajuanMenunggu',
+            'totalJadwalSelesai',
+            'totalSertifikatTerbit',
+            'totalSertifikatPerluUpload',
             'programTerbaru',
-            'pengajuanTerbaru'
+            'pengajuanTerbaru',
+            'sertifikatPerluUpload'
         ));
     }
-
 }
-

--- a/app/Http/Controllers/Admin/JadwalAsesmenController.php
+++ b/app/Http/Controllers/Admin/JadwalAsesmenController.php
@@ -20,15 +20,15 @@ class JadwalAsesmenController extends Controller
             ->latest('tanggal_mulai');
 
         if ($request->filled('status')) {
-            $query->where('status', $request->string('status'));
+            $query->where('status', $request->input('status'));
         }
 
         if ($request->filled('tanggal_dari')) {
-            $query->whereDate('tanggal_mulai', '>=', $request->string('tanggal_dari'));
+            $query->whereDate('tanggal_mulai', '>=', $request->input('tanggal_dari'));
         }
 
         if ($request->filled('tanggal_sampai')) {
-            $query->whereDate('tanggal_mulai', '<=', $request->string('tanggal_sampai'));
+            $query->whereDate('tanggal_mulai', '<=', $request->input('tanggal_sampai'));
         }
 
         if ($request->filled('search')) {

--- a/app/Http/Controllers/Admin/LaporanController.php
+++ b/app/Http/Controllers/Admin/LaporanController.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\JadwalAsesmen;
+use App\Models\Pembayaran;
+use App\Models\PengajuanSkema;
+use App\Models\ProgramPelatihan;
+use App\Models\Sertifikat;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+
+class LaporanController extends Controller
+{
+    public function index(Request $request)
+    {
+        $filters = $request->validate([
+            'tanggal_dari' => ['nullable', 'date'],
+            'tanggal_sampai' => ['nullable', 'date', 'after_or_equal:tanggal_dari'],
+            'program' => ['nullable', 'integer', 'exists:program_pelatihans,id'],
+        ]);
+
+        $programs = ProgramPelatihan::orderBy('nama')->get(['id', 'kode_skema', 'nama']);
+        $pengajuanQuery = $this->filteredPengajuanQuery($filters);
+
+        $statusPengajuan = (clone $pengajuanQuery)
+            ->select('status', DB::raw('COUNT(*) as total'))
+            ->groupBy('status')
+            ->pluck('total', 'status');
+
+        $pembayaranBerhasil = Pembayaran::query()
+            ->where('status', 'success')
+            ->whereHas('pengajuan', function (Builder $query) use ($filters) {
+                $this->applyPengajuanFilters($query, $filters);
+            });
+
+        $statistik = [
+            'total_pengajuan' => (clone $pengajuanQuery)->count(),
+            'pengajuan_disetujui' => (clone $pengajuanQuery)->whereIn('status', ['approved', 'paid'])->count(),
+            'asesmen_selesai' => JadwalAsesmen::query()
+                ->where('status', 'completed')
+                ->whereHas('pengajuan', function (Builder $query) use ($filters) {
+                    $this->applyPengajuanFilters($query, $filters);
+                })
+                ->count(),
+            'sertifikat_terbit' => Sertifikat::query()
+                ->whereHas('pengajuan', function (Builder $query) use ($filters) {
+                    $this->applyPengajuanFilters($query, $filters);
+                })
+                ->count(),
+            'pembayaran_berhasil' => (clone $pembayaranBerhasil)->count(),
+            'total_pendapatan' => (clone $pembayaranBerhasil)->sum('nominal'),
+        ];
+
+        $pengajuanPerProgram = $this->filteredPengajuanQuery($filters)
+            ->with('program')
+            ->select('program_pelatihan_id', DB::raw('COUNT(*) as total'))
+            ->groupBy('program_pelatihan_id')
+            ->orderByDesc('total')
+            ->take(10)
+            ->get();
+
+        $pengajuanList = $this->filteredPengajuanQuery($filters)
+            ->with(['user', 'program', 'pembayaran', 'jadwalAsesmen', 'sertifikat'])
+            ->latest('tanggal_pengajuan')
+            ->paginate(15)
+            ->withQueryString();
+
+        return view('admin.laporan.index', compact(
+            'filters',
+            'pengajuanList',
+            'pengajuanPerProgram',
+            'programs',
+            'statistik',
+            'statusPengajuan'
+        ));
+    }
+
+    private function filteredPengajuanQuery(array $filters): Builder
+    {
+        return $this->applyPengajuanFilters(PengajuanSkema::query(), $filters);
+    }
+
+    private function applyPengajuanFilters(Builder $query, array $filters): Builder
+    {
+        if (! empty($filters['tanggal_dari'])) {
+            $query->whereDate('tanggal_pengajuan', '>=', $filters['tanggal_dari']);
+        }
+
+        if (! empty($filters['tanggal_sampai'])) {
+            $query->whereDate('tanggal_pengajuan', '<=', $filters['tanggal_sampai']);
+        }
+
+        if (! empty($filters['program'])) {
+            $query->where('program_pelatihan_id', $filters['program']);
+        }
+
+        return $query;
+    }
+}

--- a/app/Http/Controllers/Admin/PengajuanController.php
+++ b/app/Http/Controllers/Admin/PengajuanController.php
@@ -4,12 +4,11 @@ namespace App\Http\Controllers\Admin;
 
 use App\Http\Controllers\Controller;
 use App\Models\PengajuanSkema;
+use App\Models\User;
 use App\Services\NotificationService;
 use Illuminate\Http\Request;
-use App\Models\PengajuanBuktiKompetensi;
-use App\Models\User;
-use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
 
 class PengajuanController extends Controller
 {
@@ -40,9 +39,9 @@ class PengajuanController extends Controller
         // Search
         if ($request->has('search') && $request->search != '') {
             $search = $request->search;
-            $query->whereHas('user', function($q) use ($search) {
+            $query->whereHas('user', function ($q) use ($search) {
                 $q->where('nama', 'like', "%{$search}%")
-                  ->orWhere('email', 'like', "%{$search}%");
+                    ->orWhere('email', 'like', "%{$search}%");
             });
         }
 
@@ -53,68 +52,68 @@ class PengajuanController extends Controller
     }
 
     public function show($id)
-{
-   $pengajuan = PengajuanSkema::with([
-    'user',
-    'program',
-    'apl01',
-    'buktiKompetensi.kuk.elemen.unit',
-    'pengajuanBuktiAdministratif',
-    'pengajuanBuktiPortofolio',
-    'pengajuanPersyaratanDasar',
-    'pembayaran',
-    'approver',
-    'jadwalAsesmen.asesor'
-])->findOrFail($id);
+    {
+        $pengajuan = PengajuanSkema::with([
+            'user',
+            'program',
+            'apl01',
+            'buktiKompetensi.kuk.elemen.unit',
+            'pengajuanBuktiAdministratif',
+            'pengajuanBuktiPortofolio',
+            'pengajuanPersyaratanDasar',
+            'pembayaran',
+            'approver',
+            'jadwalAsesmen.asesor',
+            'sertifikat',
+            'asesors',
+        ])->findOrFail($id);
 
+        $selfAssessments = $pengajuan->selfAssessments()->with('kuk.elemen.unit')->get();
+        $buktiKompetensi = $pengajuan->buktiKompetensi;
+        $listAsesor = User::where('role', 'asesor')->get();
+        $assignedAsesorId = $pengajuan->asesors->first()?->id;
 
-    $selfAssessments = $pengajuan->selfAssessments()->with('kuk.elemen.unit')->get();
-    $buktiKompetensi = $pengajuan->buktiKompetensi;
-    $listAsesor = User::where('role', 'asesor')->get();
-
-
-
-    return view('admin.pengajuan.show', compact('pengajuan', 'selfAssessments', 'buktiKompetensi', 'listAsesor'));
-}
+        return view('admin.pengajuan.show', compact('pengajuan', 'selfAssessments', 'buktiKompetensi', 'listAsesor', 'assignedAsesorId'));
+    }
 
     public function approve($id, Request $request)
-{
-    $request->validate([
-        'catatan_admin' => 'nullable|string'
-    ]);
+    {
+        $request->validate([
+            'catatan_admin' => 'nullable|string',
+        ]);
 
-    $pengajuan = PengajuanSkema::with(['user', 'program'])->findOrFail($id);
+        $pengajuan = PengajuanSkema::with(['user', 'program'])->findOrFail($id);
 
-    $pengajuan->update([
-        'status' => 'approved',
-        'tanggal_disetujui' => now(),
-        'catatan_admin' => $request->catatan_admin,
-        'approved_by' => Auth::id(),
-    ]);
+        $pengajuan->update([
+            'status' => 'approved',
+            'tanggal_disetujui' => now(),
+            'catatan_admin' => $request->catatan_admin,
+            'approved_by' => Auth::id(),
+        ]);
 
-    // Buat record pembayaran (tanpa snap token dulu, nanti generate saat user buka halaman bayar)
-    \App\Models\Pembayaran::create([
-        'pengajuan_skema_id' => $pengajuan->id,
-        'user_id' => $pengajuan->user_id,
-        'order_id' => \App\Models\Pembayaran::generateOrderId(),
-        'nominal' => $pengajuan->program->estimasi_biaya ?? 500000,
-        'status' => 'pending',
-        'expired_at' => now()->addDays(7), // 7 hari untuk bayar
-    ]);
+        // Buat record pembayaran (tanpa snap token dulu, nanti generate saat user buka halaman bayar)
+        \App\Models\Pembayaran::create([
+            'pengajuan_skema_id' => $pengajuan->id,
+            'user_id' => $pengajuan->user_id,
+            'order_id' => \App\Models\Pembayaran::generateOrderId(),
+            'nominal' => $pengajuan->program->estimasi_biaya ?? 500000,
+            'status' => 'pending',
+            'expired_at' => now()->addDays(7), // 7 hari untuk bayar
+        ]);
 
-    // Kirim notifikasi ke user
-    \App\Services\NotificationService::sendPengajuanApproved($pengajuan->user, $pengajuan);
+        // Kirim notifikasi ke user
+        \App\Services\NotificationService::sendPengajuanApproved($pengajuan->user, $pengajuan);
 
-    return redirect()->route('admin.pengajuan.show', $id)
-        ->with('success', 'Pengajuan berhasil disetujui.  User dapat melakukan pembayaran.');
-}
+        return redirect()->route('admin.pengajuan.show', $id)
+            ->with('success', 'Pengajuan berhasil disetujui.  User dapat melakukan pembayaran.');
+    }
 
     public function reject($id, Request $request)
     {
         $request->validate([
-            'catatan_admin' => 'required|string'
+            'catatan_admin' => 'required|string',
         ], [
-            'catatan_admin.required' => 'Catatan admin wajib diisi untuk penolakan.'
+            'catatan_admin.required' => 'Catatan admin wajib diisi untuk penolakan.',
         ]);
 
         $pengajuan = PengajuanSkema::with(['user', 'program'])->findOrFail($id);
@@ -133,27 +132,25 @@ class PengajuanController extends Controller
     }
 
     public function assignAsesor(Request $request, $pengajuanId)
-{
-    $request->validate([
-        'asesor_id' => 'required|exists:users,id'
-    ]);
+    {
+        $request->validate([
+            'asesor_id' => 'required|exists:users,id',
+        ]);
 
-    // Hapus dulu kalau sebelumnya sudah ada (biar 1 asesor saja)
-    DB::table('pengajuan_asesor')
-        ->where('pengajuan_skema_id', $pengajuanId)
-        ->delete();
+        // Hapus dulu kalau sebelumnya sudah ada (biar 1 asesor saja)
+        DB::table('pengajuan_asesor')
+            ->where('pengajuan_skema_id', $pengajuanId)
+            ->delete();
 
-    // Insert baru
-    DB::table('pengajuan_asesor')->insert([
-        'pengajuan_skema_id' => $pengajuanId,
-        'asesor_id' => $request->asesor_id,
-        'role' => 'utama',
-        'created_at' => now(),
-        'updated_at' => now(),
-    ]);
+        // Insert baru
+        DB::table('pengajuan_asesor')->insert([
+            'pengajuan_skema_id' => $pengajuanId,
+            'asesor_id' => $request->asesor_id,
+            'role' => 'utama',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
 
-    return back()->with('success', 'Asesor berhasil ditugaskan');
-}
-
-
+        return back()->with('success', 'Asesor berhasil ditugaskan');
+    }
 }

--- a/app/Http/Controllers/Admin/SertifikatController.php
+++ b/app/Http/Controllers/Admin/SertifikatController.php
@@ -7,34 +7,114 @@ use App\Models\PengajuanSkema;
 use App\Models\Sertifikat;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Storage;
+use Illuminate\Validation\Rule;
 
 class SertifikatController extends Controller
 {
+    public function index(Request $request)
+    {
+        $query = PengajuanSkema::with(['user', 'program', 'jadwalAsesmen.asesor', 'sertifikat'])
+            ->whereHas('jadwalAsesmen', function ($builder) {
+                $builder->where('status', 'completed');
+            });
+
+        if ($request->filled('search')) {
+            $search = $request->string('search')->toString();
+            $query->where(function ($builder) use ($search) {
+                $builder->whereHas('user', function ($userQuery) use ($search) {
+                    $userQuery->where('nama', 'like', "%{$search}%")
+                        ->orWhere('email', 'like', "%{$search}%");
+                })->orWhereHas('program', function ($programQuery) use ($search) {
+                    $programQuery->where('nama', 'like', "%{$search}%")
+                        ->orWhere('kode_skema', 'like', "%{$search}%");
+                })->orWhereHas('sertifikat', function ($sertifikatQuery) use ($search) {
+                    $sertifikatQuery->where('nomor_sertifikat', 'like', "%{$search}%");
+                });
+            });
+        }
+
+        if ($request->filled('status')) {
+            if ($request->status === 'terbit') {
+                $query->whereHas('sertifikat');
+            }
+
+            if ($request->status === 'belum') {
+                $query->whereDoesntHave('sertifikat');
+            }
+        }
+
+        $pengajuanList = $query->latest('updated_at')
+            ->paginate(15)
+            ->withQueryString();
+
+        $totalSiapUpload = PengajuanSkema::whereHas('jadwalAsesmen', function ($builder) {
+            $builder->where('status', 'completed');
+        })->whereDoesntHave('sertifikat')->count();
+
+        $totalTerbit = Sertifikat::count();
+
+        return view('admin.sertifikat.index', compact(
+            'pengajuanList',
+            'totalSiapUpload',
+            'totalTerbit'
+        ));
+    }
+
     public function create($pengajuanId)
     {
-        $pengajuan = PengajuanSkema::with(['user', 'program', 'sertifikat'])
+        $pengajuan = PengajuanSkema::with(['user', 'program', 'jadwalAsesmen', 'sertifikat'])
             ->findOrFail($pengajuanId);
+
+        if ($pengajuan->jadwalAsesmen?->status !== 'completed') {
+            return redirect()
+                ->route('admin.pengajuan.show', $pengajuan->id)
+                ->with('error', 'Sertifikat hanya bisa diunggah setelah jadwal asesmen berstatus selesai.');
+        }
 
         return view('admin.sertifikat.create', compact('pengajuan'));
     }
 
     public function store(Request $request, $pengajuanId)
     {
-        $pengajuan = PengajuanSkema::with(['user', 'program'])
+        $pengajuan = PengajuanSkema::with(['user', 'program', 'jadwalAsesmen', 'sertifikat'])
             ->findOrFail($pengajuanId);
 
+        if ($pengajuan->jadwalAsesmen?->status !== 'completed') {
+            return redirect()
+                ->route('admin.pengajuan.show', $pengajuan->id)
+                ->with('error', 'Sertifikat hanya bisa diunggah setelah jadwal asesmen berstatus selesai.');
+        }
+
+        $existingCertificate = $pengajuan->sertifikat;
+        $fileRules = [
+            $existingCertificate?->file_sertifikat ? 'nullable' : 'required',
+            'file',
+            'mimes:pdf,jpg,jpeg,png',
+            'max:2048',
+        ];
+
         $validated = $request->validate([
-            'nomor_sertifikat' => ['required', 'string', 'max:255', 'unique:sertifikat,nomor_sertifikat'],
+            'nomor_sertifikat' => [
+                'required',
+                'string',
+                'max:255',
+                Rule::unique('sertifikat', 'nomor_sertifikat')->ignore($existingCertificate?->id),
+            ],
             'jenis_bukti' => ['nullable', 'string', 'max:255'],
             'tanggal_terbit' => ['required', 'date'],
             'tanggal_berlaku_sampai' => ['required', 'date', 'after_or_equal:tanggal_terbit'],
-            'file_sertifikat' => ['nullable', 'file', 'mimes:pdf,jpg,jpeg,png', 'max:2048'],
+            'file_sertifikat' => $fileRules,
         ]);
 
-        $filePath = null;
+        $filePath = $existingCertificate?->file_sertifikat;
 
         if ($request->hasFile('file_sertifikat')) {
+            $oldFilePath = $filePath;
             $filePath = $request->file('file_sertifikat')->store('sertifikat', 'public');
+
+            if ($oldFilePath && Storage::disk('public')->exists($oldFilePath)) {
+                Storage::disk('public')->delete($oldFilePath);
+            }
         }
 
         Sertifikat::updateOrCreate(
@@ -53,7 +133,7 @@ class SertifikatController extends Controller
         );
 
         return redirect()
-            ->route('admin.pengajuan.show', $pengajuan->id)
-            ->with('success', 'Sertifikat berhasil diterbitkan.');
+            ->route('admin.sertifikat.index')
+            ->with('success', 'Sertifikat berhasil disimpan.');
     }
 }

--- a/app/Http/Requests/StoreJadwalAsesmenRequest.php
+++ b/app/Http/Requests/StoreJadwalAsesmenRequest.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Requests;
 
+use App\Models\JadwalAsesmen;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Rule;
 
@@ -17,7 +18,7 @@ class StoreJadwalAsesmenRequest extends FormRequest
         return [
             'pengajuan_skema_id' => ['required', 'integer', 'exists:pengajuan_skema,id'],
             'asesor_id' => ['nullable', 'integer', 'exists:users,id'],
-            'tanggal_mulai' => ['required', 'date', 'after_or_equal:now'],
+            'tanggal_mulai' => ['required', 'date'],
             'tanggal_selesai' => ['nullable', 'date', 'after:tanggal_mulai'],
             'mode_asesmen' => ['required', Rule::in(['offline', 'online'])],
             'lokasi' => ['nullable', 'string', 'max:255', 'required_if:mode_asesmen,offline'],
@@ -27,10 +28,29 @@ class StoreJadwalAsesmenRequest extends FormRequest
         ];
     }
 
+    public function withValidator($validator): void
+    {
+        $validator->after(function ($validator) {
+            if ($validator->errors()->has('tanggal_mulai') || $validator->errors()->has('pengajuan_skema_id')) {
+                return;
+            }
+
+            $hasExistingSchedule = JadwalAsesmen::where('pengajuan_skema_id', $this->input('pengajuan_skema_id'))
+                ->exists();
+
+            if (! $hasExistingSchedule && now()->gt($this->date('tanggal_mulai'))) {
+                $validator->errors()->add(
+                    'tanggal_mulai',
+                    'Tanggal mulai harus sama dengan atau setelah waktu saat ini.'
+                );
+            }
+        });
+    }
+
     public function messages(): array
     {
         return [
-            'tanggal_mulai.after_or_equal' => 'Tanggal mulai harus sama dengan atau setelah waktu saat ini.',
+            'tanggal_mulai.date' => 'Tanggal mulai harus berupa tanggal yang valid.',
             'tanggal_selesai.after' => 'Tanggal selesai harus lebih dari tanggal mulai.',
             'lokasi.required_if' => 'Lokasi wajib diisi untuk asesmen offline.',
             'tautan_meeting.required_if' => 'Tautan meeting wajib diisi untuk asesmen online.',

--- a/public/css/admin-dashboard.css
+++ b/public/css/admin-dashboard.css
@@ -30,6 +30,7 @@
     left: 0;
     top: 0;
     padding-top: 20px;
+    overflow-y: auto;
 }
 
 .sidebar-brand {
@@ -61,6 +62,7 @@
     border-radius: 8px;
     transition: all .3s;
     font-size: 14px;
+    text-decoration: none;
 }
 
 .sidebar-nav li.active a,

--- a/resources/views/admin/dashboard.blade.php
+++ b/resources/views/admin/dashboard.blade.php
@@ -1,94 +1,72 @@
 @extends('layouts.admin')
 
-@section('title', 'Manajemen Asesor')
+@section('title', 'Dashboard Admin')
 
 @section('content')
+<div class="container-fluid">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+        <div>
+            <h1 class="h4 mb-1">Dashboard Admin</h1>
+            <p class="text-muted mb-0">Ringkasan operasional sertifikasi LSP PLGM.</p>
+        </div>
+        <div class="d-flex gap-2">
+            <a href="{{ route('admin.sertifikat.index') }}" class="btn btn-outline-primary">
+                <i class="bi bi-award"></i> Upload Sertifikat
+            </a>
+            <a href="{{ route('admin.laporan.index') }}" class="btn btn-primary">
+                <i class="bi bi-bar-chart"></i> Lihat Laporan
+            </a>
+        </div>
+    </div>
 
-    {{-- KONTEN --}}
-    <div id="page-content-wrapper"><!-- 🔹 HARUS id="page-content-wrapper" -->
-
-        <nav class="admin-navbar">
-            <div class="nav-title">Panel Admin LSP PLGM</div>
-            <div class="admin-user">
-                <span class="text-muted d-none d-sm-inline">{{ now()->format('d M Y') }}</span>
-
-                <div class="dropdown">
-                    <a class="dropdown-toggle text-decoration-none" href="#" data-bs-toggle="dropdown">
-                        <i class="bi bi-person-circle me-1"></i>
-                        {{ auth()->user()->name ?? 'Administrator' }}
-                    </a>
-                    <ul class="dropdown-menu dropdown-menu-end">
-                        <li><a class="dropdown-item" href="#"><i class="bi bi-gear me-1"></i> Pengaturan Akun</a></li>
-                        <li><hr class="dropdown-divider"></li>
-                        <li>
-                            <a class="dropdown-item" href="{{ route('logout') }}"
-                               onclick="event.preventDefault(); document.getElementById('logout-form').submit();">
-                                <i class="bi bi-box-arrow-right me-1"></i> Logout
-                            </a>
-                        </li>
-                    </ul>
-                    <form id="logout-form" class="d-none" method="POST" action="{{ route('logout') }}">
-                        @csrf
-                    </form>
-                </div>
-            </div>
-        </nav>
-
-       <div class="admin-content">
-
-    {{-- STAT CARD DI ATAS --}}
     <section class="admin-stats">
         <div class="admin-card">
             <div class="info">
-                <h6>Program Pelatihan</h6>
+                <h6>Program Aktif</h6>
                 <h3>{{ $totalProgram ?? 0 }}</h3>
-                <small class="text-muted">Program aktif yang sudah dipublish</small>
+                <small class="text-muted">Program yang sudah dipublish</small>
             </div>
-            <div class="icon">
-                <i class="bi bi-journal-text"></i>
-            </div>
+            <div class="icon"><i class="bi bi-journal-text"></i></div>
         </div>
 
         <div class="admin-card">
             <div class="info">
-                <h6>Unit Kompetensi</h6>
-                <h3>{{ $totalUnit ?? 0 }}</h3>
-                <small class="text-muted">Unit kompetensi terdaftar</small>
+                <h6>Pengajuan Menunggu</h6>
+                <h3>{{ $totalPengajuanMenunggu ?? 0 }}</h3>
+                <small class="text-muted">Perlu ditinjau admin</small>
             </div>
-            <div class="icon">
-                <i class="bi bi-list-check"></i>
-            </div>
+            <div class="icon"><i class="bi bi-hourglass-split"></i></div>
         </div>
 
         <div class="admin-card">
             <div class="info">
-                <h6>Profesi Terkait</h6>
-                <h3>{{ $totalProfesi ?? 0 }}</h3>
-                <small class="text-muted">Profesi yang di-mapping ke program</small>
+                <h6>Asesmen Selesai</h6>
+                <h3>{{ $totalJadwalSelesai ?? 0 }}</h3>
+                <small class="text-muted">Siap proses hasil sertifikasi</small>
             </div>
-            <div class="icon">
-                <i class="bi bi-briefcase"></i>
-            </div>
+            <div class="icon"><i class="bi bi-calendar-check"></i></div>
         </div>
 
         <div class="admin-card">
             <div class="info">
-                <h6>Asesi Terdaftar</h6>
-                <h3>{{ $totalAsesi ?? 0 }}</h3>
-                <small class="text-muted">Akun asesi di sistem</small>
+                <h6>Sertifikat Terbit</h6>
+                <h3>{{ $totalSertifikatTerbit ?? 0 }}</h3>
+                <small class="text-muted">{{ $totalSertifikatPerluUpload ?? 0 }} masih perlu upload</small>
             </div>
-            <div class="icon">
-                <i class="bi bi-people"></i>
-            </div>
+            <div class="icon"><i class="bi bi-award"></i></div>
         </div>
     </section>
 
-    {{-- ROW BAWAH: PROGRAM TERBARU + PENDAFTARAN TERBARU --}}
     <div class="row">
-        {{-- PROGRAM PELATIHAN TERBARU --}}
         <div class="col-lg-8 mb-4">
             <div class="admin-table">
-                <h5>Program Pelatihan Terbaru</h5>
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h5 class="mb-0">Program Pelatihan Terbaru</h5>
+                    <a href="{{ route('admin.program-pelatihan.index') }}" class="btn btn-sm btn-outline-primary">
+                        Semua Program
+                    </a>
+                </div>
+
                 <div class="table-responsive">
                     <table>
                         <thead>
@@ -114,13 +92,14 @@
                                     @endif
                                 </td>
                                 <td>
-                                    <a href="{{ url('admin/program-pelatihan/'.$program->id.'/edit') }}"
-                                       class="btn-admin btn-primary-admin btn-sm">
+                                    <a href="{{ route('admin.program-pelatihan.edit', $program->id) }}"
+                                       class="btn-admin btn-primary-admin btn-sm"
+                                       title="Edit">
                                         <i class="bi bi-pencil"></i>
                                     </a>
                                     <a href="{{ url('skema/'.$program->slug) }}"
-                                       class="btn-admin btn-sm"
-                                       style="background:#e5e7eb;"
+                                       class="btn-admin btn-sm bg-light"
+                                       title="Lihat"
                                        target="_blank">
                                         <i class="bi bi-eye"></i>
                                     </a>
@@ -128,9 +107,47 @@
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="5" class="text-center text-muted">
-                                    Belum ada data program pelatihan.
+                                <td colspan="5" class="text-center text-muted">Belum ada data program pelatihan.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+
+            <div class="admin-table">
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h5 class="mb-0">Sertifikat Perlu Upload</h5>
+                    <a href="{{ route('admin.sertifikat.index', ['status' => 'belum']) }}" class="btn btn-sm btn-outline-primary">
+                        Kelola Sertifikat
+                    </a>
+                </div>
+
+                <div class="table-responsive">
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>Asesi</th>
+                            <th>Program</th>
+                            <th>Asesmen Selesai</th>
+                            <th>Aksi</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse($sertifikatPerluUpload as $pengajuan)
+                            <tr>
+                                <td>{{ $pengajuan->user->nama ?? '-' }}</td>
+                                <td>{{ \Illuminate\Support\Str::limit($pengajuan->program->nama ?? '-', 35) }}</td>
+                                <td>{{ $pengajuan->jadwalAsesmen?->tanggal_mulai?->format('d/m/Y H:i') ?? '-' }}</td>
+                                <td>
+                                    <a href="{{ route('admin.sertifikat.create', $pengajuan->id) }}" class="btn btn-sm btn-warning">
+                                        Upload
+                                    </a>
                                 </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="4" class="text-center text-muted">Tidak ada sertifikat yang menunggu upload.</td>
                             </tr>
                         @endforelse
                         </tbody>
@@ -139,10 +156,13 @@
             </div>
         </div>
 
-        {{-- PANEL KANAN: PENGAJUAN SKEMA TERBARU + INFO SISTEM --}}
         <div class="col-lg-4 mb-4">
             <div class="admin-table mb-4">
-                <h5>Pengajuan Skema Terbaru</h5>
+                <div class="d-flex justify-content-between align-items-center mb-2">
+                    <h5 class="mb-0">Pengajuan Terbaru</h5>
+                    <a href="{{ route('admin.pengajuan.index') }}" class="btn btn-sm btn-outline-primary">Semua</a>
+                </div>
+
                 <div class="table-responsive">
                     <table>
                         <thead>
@@ -155,75 +175,42 @@
                         <tbody>
                         @forelse($pengajuanTerbaru as $pengajuan)
                             <tr>
-                                <td>{{ $pengajuan->user->name ?? $pengajuan->user->nama ?? '-' }}</td>
-                                <td>{{ Str::limit($pengajuan->program->nama ?? '-', 20) }}</td>
+                                <td>{{ $pengajuan->user->nama ?? $pengajuan->user->name ?? '-' }}</td>
+                                <td>{{ \Illuminate\Support\Str::limit($pengajuan->program->nama ?? '-', 20) }}</td>
                                 <td>
                                     <span class="badge bg-{{ $pengajuan->status_badge_color }} {{ $pengajuan->status_badge_color === 'warning' ? 'text-dark' : '' }}">
-                                        {{ ucfirst($pengajuan->status ?? 'pending') }}
+                                        {{ $pengajuan->status_label }}
                                     </span>
                                 </td>
                             </tr>
                         @empty
                             <tr>
-                                <td colspan="3" class="text-center text-muted">
-                                    Belum ada pengajuan skema.
-                                </td>
+                                <td colspan="3" class="text-center text-muted">Belum ada pengajuan skema.</td>
                             </tr>
                         @endforelse
                         </tbody>
                     </table>
                 </div>
-                @if($pengajuanTerbaru->count() > 0)
-                <div class="text-end mt-2">
-                    <a href="{{ route('admin.pengajuan.index') }}" class="btn btn-sm btn-outline-primary">
-                        Lihat Semua <i class="bi bi-arrow-right"></i>
-                    </a>
-                </div>
-                @endif
             </div>
 
             <div class="admin-table">
-                <h5>Status Sistem</h5>
-                <p class="mb-2"><strong>Ringkasan:</strong></p>
-                <ul class="mb-3">
-                    <li>Pastikan data <b>Program Pelatihan</b> sudah lengkap sebelum dipublish.</li>
-                    <li>Unit Kompetensi dan Profesi Terkait sebaiknya diisi untuk setiap program.</li>
-                    <li>Jika ada perubahan SKKNI, segera update program terkait.</li>
-                </ul>
-
-                <hr>
-
-                <p class="mb-2"><strong>Quick Action</strong></p>
-                <button class="btn-admin btn-primary-admin mb-2"
-                        onclick="window.location='{{ url('admin/program-pelatihan/create') }}'">
-                    <i class="bi bi-plus-circle me-1"></i> Tambah Program Baru
-                </button>
-                <button class="btn-admin mb-2"
-                        style="background:#e5e7eb;"
-                        onclick="window.open('{{ url('skema-sertifikasi') }}','_blank')">
-                    Lihat Halaman Skema Publik
-                </button>
+                <h5>Aksi Cepat</h5>
+                <div class="d-grid gap-2">
+                    <a class="btn btn-primary" href="{{ route('admin.program-pelatihan.create') }}">
+                        <i class="bi bi-plus-circle"></i> Tambah Program Baru
+                    </a>
+                    <a class="btn btn-outline-primary" href="{{ route('admin.jadwal-asesmen.index') }}">
+                        <i class="bi bi-calendar2-week"></i> Kelola Jadwal
+                    </a>
+                    <a class="btn btn-outline-primary" href="{{ route('admin.laporan.index') }}">
+                        <i class="bi bi-bar-chart"></i> Laporan Admin
+                    </a>
+                    <a class="btn btn-outline-secondary" href="{{ url('skema-sertifikasi') }}" target="_blank">
+                        <i class="bi bi-eye"></i> Halaman Skema Publik
+                    </a>
+                </div>
             </div>
         </div>
     </div>
-
 </div>
-
-    </div>
-    {{-- /KONTEN --}}
-
-</div>
-
-<script src="{{ asset('js/bootstrap.bundle.min.js') }}"></script>
-<script>
-    // toggle sidebar di mobile
-    document.getElementById('sidebarToggle')
-        ?.addEventListener('click', function () {
-            document.getElementById('wrapper').classList.toggle('toggled');
-        });
-</script>
-
-
-
-</body>
-</html>
+@endsection

--- a/resources/views/admin/laporan/index.blade.php
+++ b/resources/views/admin/laporan/index.blade.php
@@ -1,0 +1,189 @@
+@extends('layouts.admin')
+
+@section('title', 'Laporan Admin')
+
+@section('content')
+<div class="container-fluid">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+        <div>
+            <h1 class="h4 mb-1">Laporan Admin</h1>
+            <p class="text-muted mb-0">Ringkasan pengajuan, pembayaran, asesmen, dan sertifikat.</p>
+        </div>
+        <a href="{{ route('admin.dashboard') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-speedometer2"></i> Dashboard
+        </a>
+    </div>
+
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <form method="GET" class="row g-3 align-items-end">
+                <div class="col-md-3">
+                    <label class="form-label">Tanggal Dari</label>
+                    <input type="date" name="tanggal_dari" class="form-control" value="{{ request('tanggal_dari') }}">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Tanggal Sampai</label>
+                    <input type="date" name="tanggal_sampai" class="form-control" value="{{ request('tanggal_sampai') }}">
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Program</label>
+                    <select name="program" class="form-select">
+                        <option value="">Semua program</option>
+                        @foreach($programs as $program)
+                            <option value="{{ $program->id }}" @selected((string) request('program') === (string) $program->id)>
+                                {{ $program->kode_skema }} - {{ $program->nama }}
+                            </option>
+                        @endforeach
+                    </select>
+                </div>
+                <div class="col-md-2 d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-funnel"></i> Filter
+                    </button>
+                    <a href="{{ route('admin.laporan.index') }}" class="btn btn-outline-secondary">Reset</a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <section class="admin-stats">
+        <div class="admin-card">
+            <div class="info">
+                <h6>Total Pengajuan</h6>
+                <h3>{{ $statistik['total_pengajuan'] }}</h3>
+                <small class="text-muted">Berdasarkan filter laporan</small>
+            </div>
+            <div class="icon"><i class="bi bi-file-earmark-text"></i></div>
+        </div>
+
+        <div class="admin-card">
+            <div class="info">
+                <h6>Disetujui/Dibayar</h6>
+                <h3>{{ $statistik['pengajuan_disetujui'] }}</h3>
+                <small class="text-muted">Pengajuan siap proses lanjut</small>
+            </div>
+            <div class="icon"><i class="bi bi-check2-circle"></i></div>
+        </div>
+
+        <div class="admin-card">
+            <div class="info">
+                <h6>Asesmen Selesai</h6>
+                <h3>{{ $statistik['asesmen_selesai'] }}</h3>
+                <small class="text-muted">Jadwal berstatus selesai</small>
+            </div>
+            <div class="icon"><i class="bi bi-calendar-check"></i></div>
+        </div>
+
+        <div class="admin-card">
+            <div class="info">
+                <h6>Sertifikat Terbit</h6>
+                <h3>{{ $statistik['sertifikat_terbit'] }}</h3>
+                <small class="text-muted">Sertifikat tersimpan</small>
+            </div>
+            <div class="icon"><i class="bi bi-award"></i></div>
+        </div>
+    </section>
+
+    <div class="row">
+        <div class="col-xl-8 mb-4">
+            <div class="card shadow-sm h-100">
+                <div class="card-header bg-light fw-semibold">Daftar Pengajuan</div>
+                <div class="table-responsive">
+                    <table class="table table-hover align-middle mb-0">
+                        <thead>
+                        <tr>
+                            <th>Asesi</th>
+                            <th>Program</th>
+                            <th>Status</th>
+                            <th>Pembayaran</th>
+                            <th>Jadwal</th>
+                            <th>Sertifikat</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        @forelse($pengajuanList as $pengajuan)
+                            <tr>
+                                <td>
+                                    <div class="fw-semibold">{{ $pengajuan->user->nama ?? '-' }}</div>
+                                    <small class="text-muted">{{ $pengajuan->user->email ?? '-' }}</small>
+                                </td>
+                                <td>{{ $pengajuan->program->nama ?? '-' }}</td>
+                                <td>
+                                    <span class="badge bg-{{ $pengajuan->status_badge_color }} {{ $pengajuan->status_badge_color === 'warning' ? 'text-dark' : '' }}">
+                                        {{ $pengajuan->status_label }}
+                                    </span>
+                                </td>
+                                <td>
+                                    @if($pengajuan->pembayaran)
+                                        <span class="badge bg-{{ $pengajuan->pembayaran->status_badge_color }} {{ $pengajuan->pembayaran->status_badge_color === 'warning' ? 'text-dark' : '' }}">
+                                            {{ $pengajuan->pembayaran->status_label }}
+                                        </span>
+                                    @else
+                                        <span class="text-muted">-</span>
+                                    @endif
+                                </td>
+                                <td>{{ $pengajuan->jadwalAsesmen?->status_label ?? '-' }}</td>
+                                <td>
+                                    @if($pengajuan->sertifikat)
+                                        <span class="badge bg-success">Terbit</span>
+                                    @else
+                                        <span class="badge bg-secondary">Belum</span>
+                                    @endif
+                                </td>
+                            </tr>
+                        @empty
+                            <tr>
+                                <td colspan="6" class="text-center text-muted py-4">Tidak ada data laporan.</td>
+                            </tr>
+                        @endforelse
+                        </tbody>
+                    </table>
+                </div>
+                <div class="card-footer">
+                    {{ $pengajuanList->links() }}
+                </div>
+            </div>
+        </div>
+
+        <div class="col-xl-4 mb-4">
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-light fw-semibold">Ringkasan Pembayaran</div>
+                <div class="card-body">
+                    <p class="mb-1 text-muted">Pembayaran berhasil</p>
+                    <h4 class="mb-3">{{ $statistik['pembayaran_berhasil'] }}</h4>
+                    <p class="mb-1 text-muted">Total pendapatan</p>
+                    <h4 class="mb-0">Rp {{ number_format($statistik['total_pendapatan'], 0, ',', '.') }}</h4>
+                </div>
+            </div>
+
+            <div class="card shadow-sm mb-4">
+                <div class="card-header bg-light fw-semibold">Status Pengajuan</div>
+                <div class="card-body">
+                    @forelse($statusPengajuan as $status => $total)
+                        <div class="d-flex justify-content-between border-bottom py-2">
+                            <span>{{ ucfirst($status) }}</span>
+                            <strong>{{ $total }}</strong>
+                        </div>
+                    @empty
+                        <p class="text-muted mb-0">Belum ada data status.</p>
+                    @endforelse
+                </div>
+            </div>
+
+            <div class="card shadow-sm">
+                <div class="card-header bg-light fw-semibold">Top Program</div>
+                <div class="card-body">
+                    @forelse($pengajuanPerProgram as $row)
+                        <div class="d-flex justify-content-between border-bottom py-2">
+                            <span>{{ \Illuminate\Support\Str::limit($row->program->nama ?? '-', 28) }}</span>
+                            <strong>{{ $row->total }}</strong>
+                        </div>
+                    @empty
+                        <p class="text-muted mb-0">Belum ada data program.</p>
+                    @endforelse
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/admin/pengajuan/show.blade.php
+++ b/resources/views/admin/pengajuan/show.blade.php
@@ -21,7 +21,7 @@
             <option value="">-- Pilih Asesor --</option>
             @foreach($listAsesor as $asesor)
                 <option value="{{ $asesor->id }}"
-                    {{ $pengajuan->asesor_id == $asesor->id ? 'selected' : '' }}>
+                    {{ ($assignedAsesorId ?? null) == $asesor->id ? 'selected' : '' }}>
                     {{ $asesor->nama ?? $asesor->name }} ({{ $asesor->email }})
                 </option>
             @endforeach
@@ -71,6 +71,11 @@
                             <i class="bi bi-file-earmark-pdf"></i> Lihat Sertifikat
                         </a>
                     @endif
+
+                    <a href="{{ route('admin.sertifikat.create', $pengajuan->id) }}"
+                       class="btn btn-sm btn-outline-primary mt-2">
+                        <i class="bi bi-pencil"></i> Edit Sertifikat
+                    </a>
                 </div>
             @else
                 <a href="{{ route('admin.sertifikat.create', $pengajuan->id) }}"

--- a/resources/views/admin/sertifikat/create.blade.php
+++ b/resources/views/admin/sertifikat/create.blade.php
@@ -1,78 +1,113 @@
 @extends('layouts.admin')
 
-@section('title', 'Terbitkan Sertifikat')
+@section('title', $pengajuan->sertifikat ? 'Edit Sertifikat' : 'Upload Sertifikat')
 
 @section('content')
 <div class="container-fluid">
-    <h1 class="h4 mb-4">Terbitkan Sertifikat</h1>
-
-    <div class="card mb-4">
-        <div class="card-body">
-            <p><strong>Nama Asesi:</strong> {{ $pengajuan->user->nama ?? '-' }}</p>
-            <p><strong>Email:</strong> {{ $pengajuan->user->email ?? '-' }}</p>
-            <p><strong>Skema:</strong> {{ $pengajuan->program->nama ?? '-' }}</p>
-            <p><strong>Status Pengajuan:</strong> {{ $pengajuan->status_label ?? $pengajuan->status }}</p>
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+        <div>
+            <h1 class="h4 mb-1">{{ $pengajuan->sertifikat ? 'Edit Sertifikat' : 'Upload Sertifikat' }}</h1>
+            <p class="text-muted mb-0">Simpan file sertifikat hasil sertifikasi asesi.</p>
         </div>
+        <a href="{{ route('admin.sertifikat.index') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-arrow-left"></i> Kembali
+        </a>
     </div>
 
-    <div class="card">
-        <div class="card-body">
-            <form action="{{ route('admin.sertifikat.store', $pengajuan->id) }}" method="POST" enctype="multipart/form-data">
-                @csrf
+    @if(session('error'))
+        <div class="alert alert-danger">{{ session('error') }}</div>
+    @endif
 
-                <div class="mb-3">
-                    <label class="form-label">Nomor Sertifikat</label>
-                    <input type="text" name="nomor_sertifikat" class="form-control @error('nomor_sertifikat') is-invalid @enderror"
-                           value="{{ old('nomor_sertifikat', $pengajuan->sertifikat->nomor_sertifikat ?? '') }}" required>
-                    @error('nomor_sertifikat')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
+    <div class="row g-4">
+        <div class="col-lg-4">
+            <div class="card shadow-sm">
+                <div class="card-header bg-light fw-semibold">Data Asesi</div>
+                <div class="card-body">
+                    <p class="mb-2"><strong>Nama:</strong><br>{{ $pengajuan->user->nama ?? '-' }}</p>
+                    <p class="mb-2"><strong>Email:</strong><br>{{ $pengajuan->user->email ?? '-' }}</p>
+                    <p class="mb-2"><strong>Skema:</strong><br>{{ $pengajuan->program->nama ?? '-' }}</p>
+                    <p class="mb-0">
+                        <strong>Status Asesmen:</strong><br>
+                        <span class="badge bg-{{ $pengajuan->jadwalAsesmen?->status_badge ?? 'secondary' }}">
+                            {{ $pengajuan->jadwalAsesmen?->status_label ?? '-' }}
+                        </span>
+                    </p>
                 </div>
+            </div>
+        </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Jenis Bukti</label>
-                    <input type="text" name="jenis_bukti" class="form-control"
-                           value="{{ old('jenis_bukti', $pengajuan->sertifikat->jenis_bukti ?? 'Sertifikat Kompetensi') }}">
-                </div>
+        <div class="col-lg-8">
+            <div class="card shadow-sm">
+                <div class="card-body">
+                    <form action="{{ route('admin.sertifikat.store', $pengajuan->id) }}" method="POST" enctype="multipart/form-data">
+                        @csrf
 
-                <div class="mb-3">
-                    <label class="form-label">Tanggal Terbit</label>
-                    <input type="date" name="tanggal_terbit" class="form-control @error('tanggal_terbit') is-invalid @enderror"
-                           value="{{ old('tanggal_terbit', optional($pengajuan->sertifikat->tanggal_terbit ?? null)->format('Y-m-d')) }}" required>
-                    @error('tanggal_terbit')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
+                        <div class="mb-3">
+                            <label class="form-label">Nomor Sertifikat</label>
+                            <input type="text" name="nomor_sertifikat" class="form-control @error('nomor_sertifikat') is-invalid @enderror"
+                                   value="{{ old('nomor_sertifikat', $pengajuan->sertifikat->nomor_sertifikat ?? '') }}" required>
+                            @error('nomor_sertifikat')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Berlaku Sampai</label>
-                    <input type="date" name="tanggal_berlaku_sampai" class="form-control @error('tanggal_berlaku_sampai') is-invalid @enderror"
-                           value="{{ old('tanggal_berlaku_sampai', optional($pengajuan->sertifikat->tanggal_berlaku_sampai ?? null)->format('Y-m-d')) }}" required>
-                    @error('tanggal_berlaku_sampai')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
-                </div>
+                        <div class="mb-3">
+                            <label class="form-label">Jenis Bukti</label>
+                            <input type="text" name="jenis_bukti" class="form-control @error('jenis_bukti') is-invalid @enderror"
+                                   value="{{ old('jenis_bukti', $pengajuan->sertifikat->jenis_bukti ?? 'Sertifikat Kompetensi') }}">
+                            @error('jenis_bukti')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+                        </div>
 
-                <div class="mb-3">
-                    <label class="form-label">Upload File Sertifikat</label>
-                    <input type="file" name="file_sertifikat" class="form-control @error('file_sertifikat') is-invalid @enderror">
-                    <small class="text-muted">Format: PDF, JPG, JPEG, PNG. Maksimal 2MB.</small>
-                    @error('file_sertifikat')
-                        <div class="invalid-feedback">{{ $message }}</div>
-                    @enderror
+                        <div class="row">
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label">Tanggal Terbit</label>
+                                <input type="date" name="tanggal_terbit" class="form-control @error('tanggal_terbit') is-invalid @enderror"
+                                       value="{{ old('tanggal_terbit', optional($pengajuan->sertifikat->tanggal_terbit ?? now())->format('Y-m-d')) }}" required>
+                                @error('tanggal_terbit')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
 
-                    @if(!empty($pengajuan->sertifikat->file_sertifikat))
-                        <div class="mt-2">
-                            <a href="{{ asset('storage/' . $pengajuan->sertifikat->file_sertifikat) }}" target="_blank">
-                                Lihat file sertifikat saat ini
+                            <div class="col-md-6 mb-3">
+                                <label class="form-label">Berlaku Sampai</label>
+                                <input type="date" name="tanggal_berlaku_sampai" class="form-control @error('tanggal_berlaku_sampai') is-invalid @enderror"
+                                       value="{{ old('tanggal_berlaku_sampai', optional($pengajuan->sertifikat->tanggal_berlaku_sampai ?? now()->addYears(3))->format('Y-m-d')) }}" required>
+                                @error('tanggal_berlaku_sampai')
+                                    <div class="invalid-feedback">{{ $message }}</div>
+                                @enderror
+                            </div>
+                        </div>
+
+                        <div class="mb-4">
+                            <label class="form-label">File Sertifikat</label>
+                            <input type="file" name="file_sertifikat" class="form-control @error('file_sertifikat') is-invalid @enderror" {{ $pengajuan->sertifikat?->file_sertifikat ? '' : 'required' }}>
+                            <small class="text-muted">Format PDF, JPG, JPEG, atau PNG. Maksimal 2MB.</small>
+                            @error('file_sertifikat')
+                                <div class="invalid-feedback">{{ $message }}</div>
+                            @enderror
+
+                            @if($pengajuan->sertifikat?->file_sertifikat)
+                                <div class="mt-2">
+                                    <a href="{{ asset('storage/' . $pengajuan->sertifikat->file_sertifikat) }}" target="_blank" class="btn btn-sm btn-outline-success">
+                                        <i class="bi bi-file-earmark-check"></i> Lihat file saat ini
+                                    </a>
+                                </div>
+                            @endif
+                        </div>
+
+                        <div class="d-flex flex-wrap gap-2">
+                            <button type="submit" class="btn btn-primary">
+                                <i class="bi bi-save"></i> Simpan Sertifikat
+                            </button>
+                            <a href="{{ route('admin.pengajuan.show', $pengajuan->id) }}" class="btn btn-outline-secondary">
+                                Detail Pengajuan
                             </a>
                         </div>
-                    @endif
+                    </form>
                 </div>
-
-                <button type="submit" class="btn btn-primary">Simpan Sertifikat</button>
-                <a href="{{ route('admin.pengajuan.show', $pengajuan->id) }}" class="btn btn-secondary">Kembali</a>
-            </form>
+            </div>
         </div>
     </div>
 </div>

--- a/resources/views/admin/sertifikat/index.blade.php
+++ b/resources/views/admin/sertifikat/index.blade.php
@@ -1,0 +1,148 @@
+@extends('layouts.admin')
+
+@section('title', 'Sertifikat')
+
+@section('content')
+<div class="container-fluid">
+    <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-4">
+        <div>
+            <h1 class="h4 mb-1">Upload Sertifikat</h1>
+            <p class="text-muted mb-0">Kelola file sertifikat untuk hasil asesmen yang sudah selesai.</p>
+        </div>
+        <a href="{{ route('admin.pengajuan.index') }}" class="btn btn-outline-secondary">
+            <i class="bi bi-file-earmark-text"></i> Data Pengajuan
+        </a>
+    </div>
+
+    @if(session('success'))
+        <div class="alert alert-success alert-dismissible fade show" role="alert">
+            <i class="bi bi-check-circle me-2"></i>{{ session('success') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
+    @if(session('error'))
+        <div class="alert alert-danger alert-dismissible fade show" role="alert">
+            <i class="bi bi-exclamation-triangle me-2"></i>{{ session('error') }}
+            <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+        </div>
+    @endif
+
+    <section class="admin-stats">
+        <div class="admin-card">
+            <div class="info">
+                <h6>Siap Upload</h6>
+                <h3>{{ $totalSiapUpload }}</h3>
+                <small class="text-muted">Asesmen selesai tanpa sertifikat</small>
+            </div>
+            <div class="icon"><i class="bi bi-upload"></i></div>
+        </div>
+
+        <div class="admin-card">
+            <div class="info">
+                <h6>Sertifikat Terbit</h6>
+                <h3>{{ $totalTerbit }}</h3>
+                <small class="text-muted">Total sertifikat tersimpan</small>
+            </div>
+            <div class="icon"><i class="bi bi-award"></i></div>
+        </div>
+    </section>
+
+    <div class="card shadow-sm mb-3">
+        <div class="card-body">
+            <form method="GET" class="row g-3 align-items-end">
+                <div class="col-lg-6">
+                    <label class="form-label">Pencarian</label>
+                    <input type="text" class="form-control" name="search" value="{{ request('search') }}" placeholder="Nama asesi, email, program, atau nomor sertifikat">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label">Status Sertifikat</label>
+                    <select name="status" class="form-select">
+                        <option value="">Semua status</option>
+                        <option value="belum" @selected(request('status') === 'belum')>Belum upload</option>
+                        <option value="terbit" @selected(request('status') === 'terbit')>Sudah terbit</option>
+                    </select>
+                </div>
+                <div class="col-md-3 d-flex gap-2">
+                    <button type="submit" class="btn btn-primary">
+                        <i class="bi bi-search"></i> Filter
+                    </button>
+                    <a href="{{ route('admin.sertifikat.index') }}" class="btn btn-outline-secondary">Reset</a>
+                </div>
+            </form>
+        </div>
+    </div>
+
+    <div class="card shadow-sm">
+        <div class="table-responsive">
+            <table class="table table-hover align-middle mb-0">
+                <thead class="table-light">
+                <tr>
+                    <th>Asesi</th>
+                    <th>Program</th>
+                    <th>Jadwal Selesai</th>
+                    <th>Asesor</th>
+                    <th>Status Sertifikat</th>
+                    <th style="width: 220px;">Aksi</th>
+                </tr>
+                </thead>
+                <tbody>
+                @forelse($pengajuanList as $pengajuan)
+                    <tr>
+                        <td>
+                            <div class="fw-semibold">{{ $pengajuan->user->nama ?? '-' }}</div>
+                            <small class="text-muted">{{ $pengajuan->user->email ?? '-' }}</small>
+                        </td>
+                        <td>
+                            <div>{{ $pengajuan->program->nama ?? '-' }}</div>
+                            <small class="text-muted">{{ $pengajuan->program->kode_skema ?? '-' }}</small>
+                        </td>
+                        <td>{{ $pengajuan->jadwalAsesmen?->tanggal_mulai?->format('d/m/Y H:i') ?? '-' }}</td>
+                        <td>{{ $pengajuan->jadwalAsesmen?->asesor?->nama ?? '-' }}</td>
+                        <td>
+                            @if($pengajuan->sertifikat)
+                                <span class="badge bg-success">Sudah terbit</span>
+                                <div class="small text-muted mt-1">{{ $pengajuan->sertifikat->nomor_sertifikat }}</div>
+                            @else
+                                <span class="badge bg-warning text-dark">Belum upload</span>
+                            @endif
+                        </td>
+                        <td>
+                            <div class="d-flex flex-wrap gap-2">
+                                <a href="{{ route('admin.sertifikat.create', $pengajuan->id) }}"
+                                   class="btn btn-sm {{ $pengajuan->sertifikat ? 'btn-outline-primary' : 'btn-warning' }}">
+                                    <i class="bi bi-upload"></i>
+                                    {{ $pengajuan->sertifikat ? 'Edit' : 'Upload' }}
+                                </a>
+
+                                <a href="{{ route('admin.pengajuan.show', $pengajuan->id) }}"
+                                   class="btn btn-sm btn-outline-secondary">
+                                    Detail
+                                </a>
+
+                                @if($pengajuan->sertifikat?->file_sertifikat)
+                                    <a href="{{ asset('storage/' . $pengajuan->sertifikat->file_sertifikat) }}"
+                                       target="_blank"
+                                       class="btn btn-sm btn-success">
+                                        Lihat File
+                                    </a>
+                                @endif
+                            </div>
+                        </td>
+                    </tr>
+                @empty
+                    <tr>
+                        <td colspan="6" class="text-center text-muted py-4">
+                            Belum ada asesmen selesai yang cocok dengan filter.
+                        </td>
+                    </tr>
+                @endforelse
+                </tbody>
+            </table>
+        </div>
+        <div class="card-footer">
+            {{ $pengajuanList->links() }}
+        </div>
+    </div>
+</div>
+@endsection

--- a/resources/views/layouts/admin.blade.php
+++ b/resources/views/layouts/admin.blade.php
@@ -4,30 +4,19 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <title>@yield('title', 'Admin – LSP PLGM')</title>
-    
+    <title>@yield('title', 'Admin - LSP PLGM')</title>
+
     <link rel="shortcut icon" href="{{ asset('images/logo.png') }}" type="image/x-icon" />
-
-    <!-- Bootstrap 5 CSS -->
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-
-    <!-- Bootstrap Icons -->
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.1/font/bootstrap-icons.css">
-    
-    <!-- Font Awesome -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" integrity="sha512-Avb2QiuDEEvB4bZJYdft2mNjVShBftLdPG8FJ0V7irTLQ8Uo0qcPxh4Plq7G5tGm0rU+1SPhVotteLpBERwTkw==" crossorigin="anonymous" referrerpolicy="no-referrer">
-
-    <!-- ADMIN CSS (KHUSUS) -->
     <link rel="stylesheet" href="{{ asset('css/admin-dashboard.css') }}">
-    
+
     @stack('styles')
 </head>
 
 <body class="admin-body">
-
 <div id="wrapper">
-
-    <!-- ✅ SIDEBAR -->
     <aside id="sidebar-wrapper">
         <div class="sidebar-brand">
             <img src="{{ asset('images/logo.png') }}" alt="LSP PLGM">
@@ -40,60 +29,65 @@
                 </a>
             </li>
 
-            <li class="{{ request()->is('admin/program-pelatihan*') ? 'active' : '' }}">
+            <li class="{{ request()->routeIs('admin.program-pelatihan.*') ? 'active' : '' }}">
                 <a href="{{ route('admin.program-pelatihan.index') }}">
                     <i class="bi bi-journal-text"></i> Program Pelatihan
                 </a>
             </li>
 
-
-           <li class="{{ request()->is('admin/asesi*') ? 'active' : '' }}">
-                <a href="{{ url('admin/asesi') }}">
+            <li class="{{ request()->routeIs('admin.asesi.*') ? 'active' : '' }}">
+                <a href="{{ route('admin.asesi.index') }}">
                     <i class="bi bi-people"></i> Data Asesi
                 </a>
             </li>
 
-            
-
-            <li class="{{ request() ->is('admin/pengajuan*') ? 'active' : '' }}">
-                <a href="{{ url('admin/pengajuan') }}">
+            <li class="{{ request()->routeIs('admin.pengajuan.*') ? 'active' : '' }}">
+                <a href="{{ route('admin.pengajuan.index') }}">
                     <i class="bi bi-file-earmark-text"></i> Pengajuan Sertifikasi
                 </a>
             </li>
 
-
-            <li class="{{ request()->is('admin/jadwal-asesmen*') ? 'active' : '' }}">
+            <li class="{{ request()->routeIs('admin.jadwal-asesmen.*') ? 'active' : '' }}">
                 <a href="{{ route('admin.jadwal-asesmen.index') }}">
                     <i class="bi bi-calendar2-week"></i> Jadwal Asesmen
                 </a>
             </li>
 
-            <li class="{{ request()->is('admin/pembayaran*') ? 'active' : '' }}">
+            <li class="{{ request()->routeIs('admin.sertifikat.*') ? 'active' : '' }}">
+                <a href="{{ route('admin.sertifikat.index') }}">
+                    <i class="bi bi-award"></i> Sertifikat
+                </a>
+            </li>
+
+            <li class="{{ request()->routeIs('admin.pembayaran.*') ? 'active' : '' }}">
                 <a href="{{ route('admin.pembayaran.index') }}">
                     <i class="bi bi-credit-card"></i> Pembayaran
                 </a>
             </li>
 
-            <li class="{{ request()->is('admin/livechat*') ? 'active' : '' }}">
+            <li class="{{ request()->routeIs('admin.laporan.*') ? 'active' : '' }}">
+                <a href="{{ route('admin.laporan.index') }}">
+                    <i class="bi bi-bar-chart"></i> Laporan
+                </a>
+            </li>
+
+            <li class="{{ request()->routeIs('admin.chat.*') ? 'active' : '' }}">
                 <a href="{{ route('admin.chat.index') }}">
                     <i class="bi bi-chat-dots"></i> Live Chat
                 </a>
             </li>
 
-             <li class="{{ request()->is('admin/pengguna*') ? 'active' : '' }}">
-                <a href="{{ url('admin/berita') }}">
+            <li class="{{ request()->routeIs('admin.berita.*') ? 'active' : '' }}">
+                <a href="{{ route('admin.berita.index') }}">
                     <i class="bi bi-newspaper"></i> Berita
                 </a>
             </li>
         </ul>
     </aside>
 
-    <!-- ✅ KONTEN -->
     <main id="page-content-wrapper">
-
-        <!-- ✅ NAVBAR ATAS -->
         <nav class="admin-navbar">
-            <button id="menu-toggle" class="btn">
+            <button id="menu-toggle" class="btn" type="button" aria-label="Toggle sidebar">
                 <i class="bi bi-list"></i>
             </button>
 
@@ -101,9 +95,9 @@
                 <span class="text-muted me-3">Panel Admin LSP PLGM</span>
 
                 <div class="dropdown">
-                    <a class="dropdown-toggle" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                    <a class="dropdown-toggle text-decoration-none" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false">
                         <i class="bi bi-person-circle"></i>
-                        {{ auth()->user()->name ?? 'Administrator' }}
+                        {{ auth()->user()->nama ?? auth()->user()->name ?? 'Administrator' }}
                     </a>
 
                     <div class="dropdown-menu dropdown-menu-end">
@@ -126,29 +120,25 @@
             </div>
         </nav>
 
-        <!-- ✅ KONTEN DINAMIS -->
         <section class="admin-content">
             @yield('content')
         </section>
-
     </main>
-
 </div>
 
-<!-- jQuery (optional, for legacy code) -->
 <script src="https://code.jquery.com/jquery-3.7.1.min.js" integrity="sha256-/JqT3SQfawRcv/BIHPThkBvs0OEvtFFmqPF/lYI/Cxo=" crossorigin="anonymous"></script>
-
-<!-- Bootstrap 5 Bundle (includes Popper) -->
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
 
-<!-- Admin custom JS -->
 <script>
-    document.getElementById('menu-toggle').onclick = function () {
-        document.getElementById('wrapper').classList.toggle('toggled');
+    const menuToggle = document.getElementById('menu-toggle');
+
+    if (menuToggle) {
+        menuToggle.onclick = function () {
+            document.getElementById('wrapper').classList.toggle('toggled');
+        };
     }
 </script>
 
 @stack('scripts')
-
 </body>
 </html>

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,37 +1,36 @@
 <?php
 
-use App\Http\Controllers\PendaftaranController;
-use App\Http\Controllers\AuthController;
-use App\Http\Controllers\DashboardUserController;
-use App\Http\Controllers\ProfileController;
-use App\Http\Controllers\Homecontroller;
-use Illuminate\Support\Facades\Route;
-use App\Http\Controllers\BeritaController;
-use App\Http\Controllers\TentangKamicontroller;
-use App\Http\Controllers\VisiMisicontroller;
-use App\Http\Controllers\KebijakanMutucontroller;
-use App\Http\Controllers\StrukturOrganisasicontroller;
-use App\Http\Controllers\Skemacontroller;
-use App\Http\Controllers\Admin\ProgramPelatihanController;
 use App\Http\Controllers\Admin\AdminBeritaController;
 use App\Http\Controllers\Admin\AsesiController;
-use App\Http\Controllers\Auth\PasswordResetController;
-use App\Http\Controllers\PengajuanSkemaController;
-use App\Http\Controllers\NotificationController;
-use App\Http\Controllers\PembayaranController;
-use App\Http\Controllers\ChatController;
 use App\Http\Controllers\Admin\AsesorController;
 use App\Http\Controllers\Admin\JadwalAsesmenController;
+use App\Http\Controllers\Admin\LaporanController;
+use App\Http\Controllers\Admin\ProgramPelatihanController;
+use App\Http\Controllers\Admin\SertifikatController;
 use App\Http\Controllers\Asesor\DashboardController;
+use App\Http\Controllers\Asesor\FormulirController;
 use App\Http\Controllers\Asesor\PengajuanController;
+use App\Http\Controllers\Asesor\PengaturanController;
 use App\Http\Controllers\Asesor\PenilaianController;
 use App\Http\Controllers\Asesor\ProfilController;
-use App\Http\Controllers\Asesor\PengaturanController;
-use App\Http\Controllers\Asesor\FormulirController;
+use App\Http\Controllers\Auth\PasswordResetController;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\BeritaController;
+use App\Http\Controllers\ChatController;
+use App\Http\Controllers\DashboardUserController;
+use App\Http\Controllers\Homecontroller;
+use App\Http\Controllers\KebijakanMutucontroller;
+use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\PembayaranController;
+use App\Http\Controllers\PendaftaranController;
+use App\Http\Controllers\PengajuanSkemaController;
+use App\Http\Controllers\ProfileController;
+use App\Http\Controllers\Skemacontroller;
+use App\Http\Controllers\StrukturOrganisasicontroller;
+use App\Http\Controllers\TentangKamicontroller;
+use App\Http\Controllers\VisiMisicontroller;
 use Illuminate\Support\Facades\Auth;
-use Illuminate\Http\Request;
-use App\Http\Controllers\Admin\SertifikatController;
-
+use Illuminate\Support\Facades\Route;
 
 // Pendaftaran Routes
 Route::get('/pendaftaran', [PendaftaranController::class, 'create'])->name('pendaftaran.create');
@@ -54,7 +53,7 @@ Route::get('/kebijakan-mutu', [KebijakanMutucontroller::class, 'index'])->name('
 // Struktur Organisasi Route
 Route::get('/struktur-organisasi', [StrukturOrganisasicontroller::class, 'index'])->name('struktur-organisasi');
 
-//skema sertifikasi routes
+// skema sertifikasi routes
 Route::get('/skema-sertifikasi', [Skemacontroller::class, 'index'])->name('skema.index');
 Route::get('/skema/{program:slug}', [Skemacontroller::class, 'show'])
     ->name('skema.show');
@@ -88,7 +87,7 @@ Route::get('/', [Homecontroller::class, 'index'])->name('home');
 Route::get('/berita', [BeritaController::class, 'index'])->name('berita.index');
 Route::get('/berita/{slug}', [BeritaController::class, 'show'])->name('berita.show');
 
-Route::middleware(['auth',])->group(function () {
+Route::middleware(['auth'])->group(function () {
 
     // Dashboard utama user
     Route::get('/dashboard-user', [DashboardUserController::class, 'index'])
@@ -110,11 +109,11 @@ Route::middleware(['auth',])->group(function () {
     Route::delete('/dashboard-user/profile', [ProfileController::class, 'destroy'])
         ->name('ProfileUser.destroy');
 
-    //Route Khusus Tanda Tangan
+    // Route Khusus Tanda Tangan
     Route::patch('/dashboard-user/profile/signature', [ProfileController::class, 'updateSignature'])
         ->name('ProfileUser.signature.update');
 
-     Route::get('/pengajuan/pilih-skema', [PengajuanSkemaController::class, 'pilihSkema'])
+    Route::get('/pengajuan/pilih-skema', [PengajuanSkemaController::class, 'pilihSkema'])
         ->name('pengajuan.pilih-skema');
 
     // Route untuk create pengajuan (setelah pilih skema)
@@ -141,42 +140,41 @@ Route::middleware(['auth',])->group(function () {
     Route::get('/notifications/latest', [NotificationController::class, 'getLatest'])->name('notifications.latest');
 
     // Pembayaran routes (User)
-   // Pembayaran routes (User) - dalam grup auth
-Route::get('/pembayaran/{pengajuanId}', [PembayaranController:: class, 'show'])
-    ->name('pembayaran.show');
-Route::post('/pembayaran/{pengajuanId}/process', [PembayaranController::class, 'process'])
-    ->name('pembayaran.process');
-Route::get('/pembayaran/{id}/finish', [PembayaranController::class, 'finish'])
-    ->name('pembayaran.finish');
-Route::get('/pembayaran/{pengajuanId}/check-status', [PembayaranController::class, 'checkStatus'])
-    ->name('pembayaran.check-status');
-Route::post('/pembayaran/{pengajuanId}/reset', [PembayaranController::class, 'reset'])
-    ->name('pembayaran.reset');
+    // Pembayaran routes (User) - dalam grup auth
+    Route::get('/pembayaran/{pengajuanId}', [PembayaranController::class, 'show'])
+        ->name('pembayaran.show');
+    Route::post('/pembayaran/{pengajuanId}/process', [PembayaranController::class, 'process'])
+        ->name('pembayaran.process');
+    Route::get('/pembayaran/{id}/finish', [PembayaranController::class, 'finish'])
+        ->name('pembayaran.finish');
+    Route::get('/pembayaran/{pengajuanId}/check-status', [PembayaranController::class, 'checkStatus'])
+        ->name('pembayaran.check-status');
+    Route::post('/pembayaran/{pengajuanId}/reset', [PembayaranController::class, 'reset'])
+        ->name('pembayaran.reset');
 
-// Live Chat Routes
-Route::get('/livechat', [ChatController::class, 'index'])->name('chat.index');
-Route::post('/livechat/store', [ChatController::class, 'store'])->name('chat.store');
-Route::get('/livechat/{id}', [ChatController::class, 'show'])->name('chat.show');
-Route::post('/livechat/{id}/send-message', [ChatController::class, 'sendMessage'])->name('chat.send-message');
-Route::post('/livechat/{id}/close', [ChatController::class, 'close'])->name('chat.close');
-Route::get('/livechat/{id}/get-messages', [ChatController::class, 'getMessages'])->name('chat.get-messages');
-Route::get('/livechat/get-chats', [ChatController::class, 'getChats'])->name('chat.get-chats');
+    // Live Chat Routes
+    Route::get('/livechat', [ChatController::class, 'index'])->name('chat.index');
+    Route::post('/livechat/store', [ChatController::class, 'store'])->name('chat.store');
+    Route::get('/livechat/get-chats', [ChatController::class, 'getChats'])->name('chat.get-chats');
+    Route::get('/livechat/{id}', [ChatController::class, 'show'])->name('chat.show');
+    Route::post('/livechat/{id}/send-message', [ChatController::class, 'sendMessage'])->name('chat.send-message');
+    Route::post('/livechat/{id}/close', [ChatController::class, 'close'])->name('chat.close');
+    Route::get('/livechat/{id}/get-messages', [ChatController::class, 'getMessages'])->name('chat.get-messages');
 
 });
 
-//Admin Routes
+// Admin Routes
 Route::prefix('admin')
     ->middleware(['auth', 'admin'])
     ->name('admin.')
     ->group(function () {
-// Dashboard Admin Route
+        // Dashboard Admin Route
         Route::get('/dashboard', [\App\Http\Controllers\Admin\DashboardController::class, 'index'])
             ->name('dashboard');
 
-          Route::post('/pengajuan/{id}/assign-asesor',
-        [\App\Http\Controllers\Admin\PengajuanController::class, 'assignAsesor']
+        Route::post('/pengajuan/{id}/assign-asesor',
+            [\App\Http\Controllers\Admin\PengajuanController::class, 'assignAsesor']
         )->name('pengajuan.assign-asesor');
-
 
         // CRUD Program Pelatihan
         Route::resource('program-pelatihan', ProgramPelatihanController::class);
@@ -184,7 +182,7 @@ Route::prefix('admin')
         Route::resource('asesi', AsesiController::class);
         // CRUD Asesor
         Route::resource('asesor', AsesorController::class);
-        Route::resource('berita' , AdminBeritaController::class);
+        Route::resource('berita', AdminBeritaController::class);
 
         // Pengajuan Management (Admin Only)
         Route::middleware('admin')->group(function () {
@@ -197,7 +195,6 @@ Route::prefix('admin')
             Route::post('/pengajuan/{id}/reject', [\App\Http\Controllers\Admin\PengajuanController::class, 'reject'])
                 ->name('pengajuan.reject');
 
-
             // Jadwal Asesmen Management (Admin)
             Route::get('/jadwal-asesmen', [JadwalAsesmenController::class, 'index'])
                 ->name('jadwal-asesmen.index');
@@ -207,6 +204,18 @@ Route::prefix('admin')
                 ->name('jadwal-asesmen.upsert');
             Route::patch('/jadwal-asesmen/{jadwalAsesmen}/status', [JadwalAsesmenController::class, 'setStatus'])
                 ->name('jadwal-asesmen.set-status');
+
+            // Sertifikat Management (Admin)
+            Route::get('/sertifikat', [SertifikatController::class, 'index'])
+                ->name('sertifikat.index');
+            Route::get('/pengajuan/{id}/sertifikat/create', [SertifikatController::class, 'create'])
+                ->name('sertifikat.create');
+            Route::post('/pengajuan/{id}/sertifikat', [SertifikatController::class, 'store'])
+                ->name('sertifikat.store');
+
+            // Laporan Management (Admin)
+            Route::get('/laporan', [LaporanController::class, 'index'])
+                ->name('laporan.index');
 
             // Pembayaran Management (Admin)
             Route::get('/pembayaran', [\App\Http\Controllers\Admin\PembayaranController::class, 'index'])
@@ -221,6 +230,10 @@ Route::prefix('admin')
             // Live Chat Management (Admin)
             Route::get('/livechat', [\App\Http\Controllers\Admin\ChatController::class, 'index'])
                 ->name('chat.index');
+            Route::get('/livechat/get-chats', [\App\Http\Controllers\Admin\ChatController::class, 'getChats'])
+                ->name('chat.get-chats');
+            Route::get('/livechat/get-stats', [\App\Http\Controllers\Admin\ChatController::class, 'getStats'])
+                ->name('chat.get-stats');
             Route::get('/livechat/{id}', [\App\Http\Controllers\Admin\ChatController::class, 'show'])
                 ->name('chat.show');
             Route::post('/livechat/{id}/send-message', [\App\Http\Controllers\Admin\ChatController::class, 'sendMessage'])
@@ -233,20 +246,8 @@ Route::prefix('admin')
                 ->name('chat.unassign');
             Route::get('/livechat/{id}/get-messages', [\App\Http\Controllers\Admin\ChatController::class, 'getMessages'])
                 ->name('chat.get-messages');
-            Route::get('/livechat/get-chats', [\App\Http\Controllers\Admin\ChatController::class, 'getChats'])
-                ->name('chat.get-chats');
-            Route::get('/livechat/get-stats', [\App\Http\Controllers\Admin\ChatController::class, 'getStats'])
-                ->name('chat.get-stats');
-
-            // Sertifikat Management (Admin)
-            Route::get('/pengajuan/{id}/sertifikat/create', [SertifikatController::class, 'create'])
-                ->name('sertifikat.create');
-            Route::post('/pengajuan/{id}/sertifikat', [SertifikatController::class, 'store'])
-                ->name('sertifikat.store');
 
         });
-
-
 
     });
 
@@ -283,11 +284,3 @@ Route::middleware(['auth', 'role:asesor'])->prefix('asesor')->name('asesor.')->g
 Route::get('/cek-midtrans', function () {
     return config('midtrans');
 });
-
-
-
-
-
-
-
-

--- a/tests/Feature/Admin/JadwalAsesmenSertifikatTest.php
+++ b/tests/Feature/Admin/JadwalAsesmenSertifikatTest.php
@@ -1,0 +1,164 @@
+<?php
+
+namespace Tests\Feature\Admin;
+
+use App\Models\JadwalAsesmen;
+use App\Models\PengajuanSkema;
+use App\Models\ProgramPelatihan;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+use Tests\TestCase;
+
+class JadwalAsesmenSertifikatTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_admin_can_create_jadwal_asesmen(): void
+    {
+        [$admin, $asesor, $pengajuan] = $this->makeApprovedPengajuan();
+
+        $tanggalMulai = now()->addDay();
+
+        $response = $this->actingAs($admin)->post(route('admin.jadwal-asesmen.upsert'), [
+            'pengajuan_skema_id' => $pengajuan->id,
+            'asesor_id' => $asesor->id,
+            'tanggal_mulai' => $tanggalMulai->format('Y-m-d H:i:s'),
+            'tanggal_selesai' => $tanggalMulai->copy()->addHours(2)->format('Y-m-d H:i:s'),
+            'mode_asesmen' => 'online',
+            'tautan_meeting' => 'https://meet.example.com/asesmen',
+            'status' => 'scheduled',
+            'catatan' => 'Jadwal test',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+
+        $this->assertDatabaseHas('jadwal_asesmen', [
+            'pengajuan_skema_id' => $pengajuan->id,
+            'asesor_id' => $asesor->id,
+            'mode_asesmen' => 'online',
+            'status' => 'scheduled',
+        ]);
+    }
+
+    public function test_admin_can_mark_existing_past_jadwal_as_completed(): void
+    {
+        [$admin, $asesor, $pengajuan] = $this->makeApprovedPengajuan();
+
+        $jadwal = JadwalAsesmen::create([
+            'pengajuan_skema_id' => $pengajuan->id,
+            'asesor_id' => $asesor->id,
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+            'tanggal_mulai' => now()->subDay(),
+            'tanggal_selesai' => now()->subDay()->addHours(2),
+            'mode_asesmen' => 'offline',
+            'lokasi' => 'Ruang Asesmen',
+            'status' => 'scheduled',
+        ]);
+
+        $response = $this->actingAs($admin)->post(route('admin.jadwal-asesmen.upsert'), [
+            'pengajuan_skema_id' => $pengajuan->id,
+            'asesor_id' => $asesor->id,
+            'tanggal_mulai' => $jadwal->tanggal_mulai->format('Y-m-d H:i:s'),
+            'tanggal_selesai' => $jadwal->tanggal_selesai->format('Y-m-d H:i:s'),
+            'mode_asesmen' => 'offline',
+            'lokasi' => 'Ruang Asesmen',
+            'status' => 'completed',
+        ]);
+
+        $response->assertRedirect();
+        $response->assertSessionHasNoErrors();
+
+        $this->assertDatabaseHas('jadwal_asesmen', [
+            'pengajuan_skema_id' => $pengajuan->id,
+            'status' => 'completed',
+        ]);
+    }
+
+    public function test_admin_can_upload_certificate_after_assessment_completed(): void
+    {
+        Storage::fake('public');
+
+        [$admin, $asesor, $pengajuan] = $this->makeApprovedPengajuan();
+
+        JadwalAsesmen::create([
+            'pengajuan_skema_id' => $pengajuan->id,
+            'asesor_id' => $asesor->id,
+            'created_by' => $admin->id,
+            'updated_by' => $admin->id,
+            'tanggal_mulai' => now()->subDay(),
+            'tanggal_selesai' => now()->subDay()->addHours(2),
+            'mode_asesmen' => 'offline',
+            'lokasi' => 'Ruang Asesmen',
+            'status' => 'completed',
+        ]);
+
+        $response = $this->actingAs($admin)->post(route('admin.sertifikat.store', $pengajuan->id), [
+            'nomor_sertifikat' => 'CERT-001',
+            'jenis_bukti' => 'Sertifikat Kompetensi',
+            'tanggal_terbit' => now()->format('Y-m-d'),
+            'tanggal_berlaku_sampai' => now()->addYears(3)->format('Y-m-d'),
+            'file_sertifikat' => UploadedFile::fake()->create('sertifikat.pdf', 100, 'application/pdf'),
+        ]);
+
+        $response->assertRedirect(route('admin.sertifikat.index'));
+        $response->assertSessionHasNoErrors();
+
+        $sertifikat = $pengajuan->fresh('sertifikat')->sertifikat;
+
+        $this->assertNotNull($sertifikat);
+        $this->assertEquals('CERT-001', $sertifikat->nomor_sertifikat);
+        Storage::disk('public')->assertExists($sertifikat->file_sertifikat);
+    }
+
+    public function test_admin_report_page_loads(): void
+    {
+        [$admin] = $this->makeApprovedPengajuan();
+
+        $response = $this->actingAs($admin)->get(route('admin.laporan.index'));
+
+        $response->assertOk();
+        $response->assertViewHas('statistik');
+        $response->assertViewHas('pengajuanList');
+    }
+
+    private function makeApprovedPengajuan(): array
+    {
+        $admin = User::factory()->create([
+            'role' => 'admin',
+        ]);
+
+        $asesor = User::factory()->create([
+            'role' => 'asesor',
+        ]);
+
+        $asesi = User::factory()->create([
+            'role' => 'user',
+        ]);
+
+        $program = ProgramPelatihan::create([
+            'kode_skema' => 'SKM-TEST',
+            'nama' => 'Skema Test',
+            'slug' => 'skema-test',
+            'kategori' => 'Testing',
+            'kategori_slug' => 'testing',
+            'jumlah_unit' => 1,
+            'estimasi_biaya' => 500000,
+            'is_published' => true,
+        ]);
+
+        $pengajuan = PengajuanSkema::create([
+            'user_id' => $asesi->id,
+            'program_pelatihan_id' => $program->id,
+            'status' => 'approved',
+            'tanggal_pengajuan' => now()->subDays(2),
+            'tanggal_disetujui' => now()->subDay(),
+            'approved_by' => $admin->id,
+        ]);
+
+        return [$admin, $asesor, $pengajuan];
+    }
+}


### PR DESCRIPTION
## Summary
- Add an admin Sertifikat page for completed assessments, with upload/edit support for certificate files.
- Add an admin Laporan page with filters and reporting summaries for submissions, payments, assessments, and certificates.
- Refresh the admin dashboard/sidebar, fix certificate edit behavior, relax schedule status updates for existing past assessments, and fix livechat static route ordering.

## Verification
- `composer install --no-interaction --prefer-dist`
- `vendor\\bin\\pint app/Http/Controllers/Admin/DashboardController.php app/Http/Controllers/Admin/JadwalAsesmenController.php app/Http/Controllers/Admin/LaporanController.php app/Http/Controllers/Admin/PengajuanController.php app/Http/Controllers/Admin/SertifikatController.php app/Http/Requests/StoreJadwalAsesmenRequest.php routes/web.php tests/Feature/Admin/JadwalAsesmenSertifikatTest.php`
- `php artisan route:list --name=admin.sertifikat`
- `php artisan route:list --name=admin.laporan`
- `php artisan view:cache`

## Test note
- `php artisan test --filter=JadwalAsesmenSertifikatTest` is currently blocked in this environment because PHP has `pdo_mysql` but not `pdo_sqlite`, while `phpunit.xml` uses SQLite in-memory. Error: `could not find driver`.